### PR TITLE
Use babel via babelify.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,13 +23,12 @@
  */
 'use strict';
 
+let babelify = require('babelify');
 let browserify = require('browserify');
 let eslint = require('gulp-eslint');
 let espowerify = require('espowerify');
-let envify = require('envify');
 let exorcist = require('exorcist'); // Split sourcemap into the file.
 let gulp = require('gulp');
-let reactify = require('reactify');
 let sass = require('gulp-sass');
 let source = require('vinyl-source-stream');
 
@@ -79,9 +78,14 @@ gulp.task('js', ['jslint'], function() {
         debug: !isRelease,
     };
 
+    let babel = babelify.configure({
+        optional: [
+            'utility.inlineEnvironmentVariables',
+        ],
+    });
+
     browserify(SRC_JS, option)
-        .transform(reactify)
-        .transform(envify)
+        .transform(babel)
         .bundle()
         .pipe(exorcist(DIST_JS_MAP_FILE))
         .pipe(source('bundle.js'))

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "react": "^0.13.1"
   },
   "devDependencies": {
+    "babel-core": "^5.5.8",
+    "babelify": "^6.0.2",
     "browserify": "^10.0.0",
-    "envify": "^3.4.0",
     "eslint-plugin-react": "^2.2.0",
     "espowerify": "^0.10.0",
     "exorcist": "^0.3.0",
@@ -43,7 +44,6 @@
     "karma-mocha-reporter": "^1.0.2",
     "mocha": "^2.2.1",
     "power-assert": "^0.11.0",
-    "reactify": "^1.1.0",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^3.6.0"
   }


### PR DESCRIPTION
## Remove envify.

Babel has [the pass to inlines environment variables](http://babeljs.io/docs/advanced/transformers/utility/inline-environment-variables/).
## Remove reactify.

Babel has [the pass to transform JSX syntax](http://babeljs.io/docs/usage/transformers/other/react/).
## react-tools is deprecated

see: http://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html
